### PR TITLE
feat(terraform): Update EKS and Karpenter configuration to latest ver…

### DIFF
--- a/terraform/manifests/karpenter-chart/values-gpu.yaml
+++ b/terraform/manifests/karpenter-chart/values-gpu.yaml
@@ -7,9 +7,9 @@ clusterName: ""  # Will be set from Terraform
 nodeClasses:
   - enabled: true
     name: "gpu-nodeclass"
-    amiFamily: "AL2"
+    amiFamily: "AL2023"
     amiSelectorTerms:
-      - name: "amazon-eks-gpu-node-1.31-*"
+      - name: "amazon-eks-node-al2023-x86_64-nvidia-1.34-*"
         owners: ["amazon"]
     blockDeviceMappings:
       - deviceName: "/dev/xvda"


### PR DESCRIPTION
…sions

- Upgrade EKS module to version 21.4
- Update Kubernetes version from 1.31 to 1.34
- Modify cluster configuration with new parameter names
- Add explicit EKS addons configuration
- Update Karpenter module to version 21.4
- Change AMI family from AL2 to AL2023
- Update AMI selector to match new Kubernetes version
- Adjust Terraform provider requirements and versions
- Remove deprecated configuration options
- Simplify module configuration and tagging

This update ensures compatibility with the latest EKS and Karpenter versions, improving cluster management and configuration flexibility.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
